### PR TITLE
fix: changed the page to health check of the backend

### DIFF
--- a/survey/run_and_test.sh
+++ b/survey/run_and_test.sh
@@ -63,7 +63,7 @@ echo "Running backend on port 5000."
 gunicorn --bind 0.0.0.0:5000 backend.src.app:app --daemon
 sleep 5
 echo "checking if the server is up"
-HTTP_CODE=$(curl --write-out "%{http_code}\n" "$API_URL" --output output.txt --silent)
+HTTP_CODE=$(curl --write-out "%{http_code}\n" "$API_URL/survey" --output output.txt --silent)
 
 if [ $HTTP_CODE -ne 200 ]
 then


### PR DESCRIPTION
The backend does not offer an index page (`/`). Hence, it returns 404, instead of 200. Hence, this `run_and_tesh.sh` was fixed to use `/survey` as a health check page. The better way is to create an index page returning an empty page with status code 204. 