### PR TITLE
feat: implement recursive clustering which reaches the granularity where one leaf cluster has only one user

### DIFF
--- a/survey/backend/src/strategies/preprocessing/hierarchical_clustering.py
+++ b/survey/backend/src/strategies/preprocessing/hierarchical_clustering.py
@@ -1,66 +1,113 @@
-
 from sklearn.cluster import KMeans
 from survey.backend.src.strategies.preprocessing.matrix_builder import MatrixBuilder
 
 
+def depth(l):
+    if isinstance(l, list):
+        return 1 + max(depth(item) for item in l)
+    else:
+        return 0
+
+
 class HierarchicalCluster:
+    class UserCluster:
+        def __init__(self, is_root=False):
+            self.is_root: bool = is_root
+            self.parent_cluster = None
+            self.child_clusters = []
+            self.user_ids: [int] = []
+            self.user_cnt: int = None
+
+        def __repr__(self):
+            return repr(f'{self.user_cnt}: {self.user_ids}')
+
     def __init__(self, ratings_df):
+
         self.ratings_df = ratings_df
+        matrix_builder = MatrixBuilder(self.ratings_df)
+        rating_matrix = matrix_builder.rating_matrix
+
+        # TODO: consider other options for the fillna
+        # filling the missing data with the average rating of the item
+        self.rating_matrix = rating_matrix.fillna(rating_matrix.mean())
+
+
+
+        self.root_cluster = self.UserCluster(is_root=True)
+        self.root_cluster.user_ids = self.rating_matrix.index.to_list()
+        self.root_cluster.user_cnt = len(self.root_cluster.user_ids)
+        self.build_child_clusters(self.root_cluster)
 
         # depth is the level of the hierarchy
         # it is highly relevant with the number of questions to ask to users.
         # If the cluster has N depths, users will be asked N questions to match the user with a cluster
-        self.depth = 0
-        self.cluster_labels = []
+        self.depth = 1 + depth(self.root_cluster.child_clusters)
 
-    # elbow method provides a desirable number of clusters for k-means clustering
-    def get_desriable_cluster_num_with_elbow_method(self, curr_ratings_df):
-        matrix_builder = MatrixBuilder(curr_ratings_df)
-        rating_matrix = matrix_builder.rating_matrix
+    def build_child_clusters(self, curr_cluster: UserCluster):
 
-        # filling the missing data with the average rating of the item
-        rating_matrix = rating_matrix.fillna(rating_matrix.mean())
+        # run k-means clusters based on elbow method
 
-        inertias = []
+        curr_rating_matrix = self.rating_matrix.loc[curr_cluster.user_ids]
+        unique_user_cnt = curr_rating_matrix.shape[0]
 
-        unique_user_cnt = len(self.ratings_df['userId'].unique())
-
+        # assign the current cluster(self) as the parent cluster to the child clusters
         # handling exceptional cases where the users are too few
         if unique_user_cnt <= 5:
-            return 2
 
-        # choose the number of clusters between 2 to the (total number of unique users - 1) / 2
-        # limiting up to 5 clusters as too many clusters make it harder to choose an option among them
-        K = range(1, 1+5)
+            kmeanModel = KMeans(n_clusters=2)
+            kmeanModel.fit(curr_rating_matrix)
+            best_k_means = kmeanModel
 
-        kmeanModels = []
+        else:
 
-        for k in K:
-            kmeanModel = KMeans(n_clusters=k)
-            kmeanModel.fit(rating_matrix)
+            # choose the number of clusters between 2 to the (total number of unique users - 1) / 2
+            # limiting up to 5 clusters as too many clusters make it harder to choose an option among them
+            K = range(1, int(unique_user_cnt / 2))
+            # K = range(1, 1 + 5)
 
-            # keeping the current model until we know the desirable k
-            kmeanModels.append(kmeanModel)
+            kmeanModels = []
+            inertias = []
 
-            # Inertia is the sum of the squared distainces of *samples* to their closest cluster center
-            inertia = kmeanModel.inertia_
-            inertias.append(inertia)
+            for k in K:
+                kmeanModel = KMeans(n_clusters=k)
+                kmeanModel.fit(curr_rating_matrix)
 
-        # we look for the *elbow* here
-        # elbow is the number of clusters
-        # where the linearly decreasing inertia starts to decrease slower than the previous numbers
-        for idx in range(0, len(inertias)):
-            # excluding 1 cluster at idx 0 because 1 will make the hierarchical clustering infinite
-            if idx == 0:
-                pass
-            elif inertias[idx - 1] - inertias[idx] > inertias[idx] - inertias[idx + 1]:
-                self.cluster_labels = kmeanModels[idx].labels_
-                return idx + 1
-            # if there's no elbow at last, return the last idx
-            elif idx == len(inertias) - 1:
-                self.cluster_labels = kmeanModels[idx].labels_
-                return idx + 1
+                # keeping the current model until we know the desirable k
+                kmeanModels.append(kmeanModel)
 
+                # Inertia is the sum of the squared distances of *samples* to their closest cluster center
+                inertia = kmeanModel.inertia_
+                inertias.append(inertia)
 
+            desirable_k = None
 
+            # we look for the *elbow* here
+            # elbow is the number of clusters
+            # where the linearly decreasing inertia starts to decrease slower than the previous numbers
+            for idx in range(0, len(inertias)):
+                # excluding 1 cluster at idx 0 because 1 will make the hierarchical clustering infinite
+                if idx == 0:
+                    pass
+                # if there's no elbow at last, return the last idx
+                elif idx == len(inertias) - 1:
+                    desirable_k = idx + 1
+                elif inertias[idx - 1] - inertias[idx] > inertias[idx] - inertias[idx + 1]:
+                    desirable_k = idx + 1
 
+            best_k_means = kmeanModels[desirable_k - 1]
+
+        curr_rating_matrix['labels'] = best_k_means.labels_
+
+        # for each child cluster, assign the parent cluster and user_ids
+        for each_label in range(best_k_means.n_clusters):
+            child_rating_matrix = curr_rating_matrix[curr_rating_matrix['labels'] == each_label]
+            child = self.UserCluster()
+            child.user_ids = child_rating_matrix.index.to_list()
+            child.user_cnt = len(child.user_ids)
+            child.parent_cluster = curr_cluster
+
+            curr_cluster.child_clusters.append(child)
+
+        for each_child in curr_cluster.child_clusters:
+            if len(each_child.user_ids) > 1:
+                self.build_child_clusters(curr_cluster=each_child)


### PR DESCRIPTION
This PR adds a function called `build_child_clusters` where it recursively clusters the users. This recursive clustering classifies users into a group in a deterministic way like a decision tree. This decision tree will be used as the step-by-step path to match one offline user.