### PR TITLE
feat: reduce the dimensions PCA and always cluster users into 5 groups

### DIFF
--- a/survey/backend/src/routes/questionnaire/helper_functions.py
+++ b/survey/backend/src/routes/questionnaire/helper_functions.py
@@ -91,7 +91,7 @@ def send_next_item_and_current_ratings(participant_token):
     rel_dataset = db.session.query(Dataset).filter_by(id=rel_survey.dataset_id).first()
     rel_strategy_name = rel_survey.item_selection_strategy
 
-    ## new item selection strategies are stored in the src/matchmaking folder
+    ## new item selection strategies are stored in the src/strategies/next_question_selection folder
     ## each file has a different name but contains a class called Strategy in it
 
     ## load the related strategy file (module) from the directory

--- a/survey/backend/src/routes/questionnaire/questionnaire.py
+++ b/survey/backend/src/routes/questionnaire/questionnaire.py
@@ -8,6 +8,7 @@ from .helper_functions import save_ratings, send_next_item_and_current_ratings, 
 ## create a blueprint for this route to be easily added to root later.
 questionnaire_bp = Blueprint('questionnaire', __name__)
 
+
 @questionnaire_bp.route('/questionnaire', methods = ['POST', 'GET'])
 @cross_origin(supports_credentials=True)
 def handle_questionnaire():

--- a/survey/backend/src/routes/questionnaire/questionnaire.py
+++ b/survey/backend/src/routes/questionnaire/questionnaire.py
@@ -9,13 +9,12 @@ from .helper_functions import save_ratings, send_next_item_and_current_ratings, 
 questionnaire_bp = Blueprint('questionnaire', __name__)
 
 
-@questionnaire_bp.route('/questionnaire', methods = ['POST', 'GET'])
+@questionnaire_bp.route('/questionnaire', methods=['POST', 'GET'])
 @cross_origin(supports_credentials=True)
 def handle_questionnaire():
 
     if request.method == "GET":
         token = request.args.get('token')
-        print(f"token = {token}")
         survey_info = send_survey_details(token)
         return json.dumps(survey_info)
     

--- a/survey/backend/src/strategies/next_question_selection/abstract_class/item_selection_base.py
+++ b/survey/backend/src/strategies/next_question_selection/abstract_class/item_selection_base.py
@@ -9,7 +9,7 @@ import pandas as pd
 class BaseStrategy(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def __init__(self, rating_df: pd.DataFrame):
-        self.rating_df: pd.DataFrame = rating_df
+         self.rating_df: pd.DataFrame = rating_df
 
     @abc.abstractmethod
     def get_next_item(self, current_ratings: str) -> str:

--- a/survey/backend/src/strategies/next_question_selection/abstract_class/item_selection_base.py
+++ b/survey/backend/src/strategies/next_question_selection/abstract_class/item_selection_base.py
@@ -9,7 +9,7 @@ import pandas as pd
 class BaseStrategy(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def __init__(self, rating_df: pd.DataFrame):
-         self.rating_df: pd.DataFrame = rating_df
+        self.rating_df: pd.DataFrame = rating_df
 
     @abc.abstractmethod
     def get_next_item(self, current_ratings: str) -> str:

--- a/survey/backend/src/strategies/preprocessing/hierarchical_clustering.py
+++ b/survey/backend/src/strategies/preprocessing/hierarchical_clustering.py
@@ -9,7 +9,7 @@ from backend.src.strategies.preprocessing.matrix_builder import MatrixBuilder
 # for example, if this var is 5, users will see at most 5 options to choose among at each question.
 from backend.src.strategies.preprocessing.utils import clustered_result_path, raw_dataset_path
 
-MAXIMUM_CANDIDATES = 7
+MAXIMUM_CANDIDATES = 5
 
 
 def depth(l):
@@ -26,7 +26,7 @@ class HierarchicalCluster:
             self.parent_cluster = None
             self.child_clusters = []
             self.user_ids: [int] = []
-            self.user_cnt: int = None
+            self.user_cnt: int = 0
 
         def __repr__(self):
             return repr(f'{self.user_cnt}: {self.user_ids}')
@@ -66,14 +66,23 @@ class HierarchicalCluster:
         # filling the missing data with the column-wise (item-wise) average rating of the item
         return rating_matrix.fillna(rating_matrix.mean(), axis=0)
 
+    def reduce_dimensions(self):
+        # reduce the dimensions of rating_matrix by running PCA
+
+        return
+
     def cluster_users_by_rating(self):
         root_cluster = self.UserCluster(is_root=True)
         root_cluster.user_ids = self.rating_matrix.index.to_list()
         root_cluster.user_cnt = len(root_cluster.user_ids)
+
+        # if you'd like to use elbow method, not using the default value 5 for the clustering,
+        # set the `elbow_method` argument as True
+        # i.e. self.build_child_clusters(root_cluster, True)
         self.build_child_clusters(root_cluster)
         return root_cluster
 
-    def build_child_clusters(self, curr_cluster: UserCluster):
+    def build_child_clusters(self, curr_cluster: UserCluster, elbow_method: bool = False):
 
         # run k-means clusters based on elbow method
         curr_rating_matrix = self.rating_matrix.loc[curr_cluster.user_ids]
@@ -88,42 +97,46 @@ class HierarchicalCluster:
             best_k_means = kmeanModel
 
         else:
-            # TODO: consider if the number should be any smaller (i.e. 5)
-            # find the desirable number of clusters
-            # limiting between 2 to smaller number between (total number of unique users - 1) / 2 or 7
-            # as too many clusters make it harder to choose an option among them
-            K = range(1, min(int(unique_user_cnt / 2) + 1, MAXIMUM_CANDIDATES + 1))
+            if elbow_method:
+                # find the desirable number of clusters
+                # limiting between 2 to smaller number between (total number of unique users - 1) / 2 or 7
+                # as too many clusters make it harder to choose an option among them
+                K = range(1, min(int(unique_user_cnt / 2) + 1, MAXIMUM_CANDIDATES + 1))
 
-            kmeanModels = []
-            inertias = []
+                kmeanModels = []
+                inertias = []
 
-            for k in K:
-                kmeanModel = KMeans(n_clusters=k)
-                kmeanModel.fit(curr_rating_matrix)
+                for k in K:
+                    kmeanModel = KMeans(n_clusters=k)
+                    kmeanModel.fit(curr_rating_matrix)
 
-                # keeping the current model until we know the desirable k
-                kmeanModels.append(kmeanModel)
+                    # keeping the current model until we know the desirable k
+                    kmeanModels.append(kmeanModel)
 
-                # Inertia is the sum of the squared distances of *samples* to their closest cluster center
-                inertia = kmeanModel.inertia_
-                inertias.append(inertia)
+                    # Inertia is the sum of the squared distances of *samples* to their closest cluster center
+                    inertia = kmeanModel.inertia_
+                    inertias.append(inertia)
 
-            desirable_k = None
+                desirable_k = None
 
-            # we look for the *elbow* here
-            # elbow is the number of clusters
-            # where the linearly decreasing inertia starts to decrease slower than the previous numbers
-            for idx in range(0, len(inertias)):
-                # excluding 1 cluster at idx 0 because 1 will make the hierarchical clustering infinite
-                if idx == 0:
-                    pass
-                # if there's no elbow at last, return the last idx
-                elif idx == len(inertias) - 1:
-                    desirable_k = idx + 1
-                elif inertias[idx - 1] - inertias[idx] > inertias[idx] - inertias[idx + 1]:
-                    desirable_k = idx + 1
+                # we look for the *elbow* here
+                # elbow is the number of clusters
+                # where the linearly decreasing inertia starts to decrease slower than the previous numbers
+                for idx in range(0, len(inertias)):
+                    # excluding 1 cluster at idx 0 because 1 will make the hierarchical clustering infinite
+                    if idx == 0:
+                        pass
+                    # if there's no elbow at last, return the last idx
+                    elif idx == len(inertias) - 1:
+                        desirable_k = idx + 1
+                    elif inertias[idx - 1] - inertias[idx] > inertias[idx] - inertias[idx + 1]:
+                        desirable_k = idx + 1
 
-            best_k_means = kmeanModels[desirable_k - 1]
+                best_k_means = kmeanModels[desirable_k - 1]
+
+            else:
+                best_k_means = KMeans(n_clusters=MAXIMUM_CANDIDATES)
+                best_k_means.fit(curr_rating_matrix)
 
         curr_rating_matrix['labels'] = best_k_means.labels_
 

--- a/survey/backend/src/strategies/preprocessing/hierarchical_clustering.py
+++ b/survey/backend/src/strategies/preprocessing/hierarchical_clustering.py
@@ -133,7 +133,13 @@ class HierarchicalCluster:
                 best_k_means = kmeanModels[desirable_k - 1]
 
             else:
-                best_k_means = KMeans(n_clusters=MAXIMUM_CANDIDATES)
+                ## without PCA:
+                # best_k_means = KMeans(n_clusters=MAXIMUM_CANDIDATES)
+
+                ## with PCA:
+                pca = PCA(n_components=MAXIMUM_CANDIDATES).fit(curr_rating_matrix)
+                best_k_means = KMeans(init=pca.components_, n_clusters=MAXIMUM_CANDIDATES)
+
                 best_k_means.fit(curr_rating_matrix)
 
         curr_rating_matrix['labels'] = best_k_means.labels_

--- a/survey/backend/src/strategies/preprocessing/hierarchical_clustering.py
+++ b/survey/backend/src/strategies/preprocessing/hierarchical_clustering.py
@@ -3,11 +3,14 @@ import pandas as pd
 import pickle
 
 from sklearn.cluster import KMeans
+from sklearn.decomposition import PCA
+
 from backend.src.strategies.preprocessing.matrix_builder import MatrixBuilder
 
 # the number of candidates (options) at questions for the online users
 # for example, if this var is 5, users will see at most 5 options to choose among at each question.
 from backend.src.strategies.preprocessing.utils import clustered_result_path, raw_dataset_path
+
 
 MAXIMUM_CANDIDATES = 5
 
@@ -42,7 +45,7 @@ class HierarchicalCluster:
                 self.rating_matrix = temp_hc.rating_matrix
         else:
             rating_df = pd.read_csv(raw_dataset_path(dataset_name))
-            self.rating_matrix = self.preprocess_and_fillna(rating_df)
+            self.rating_matrix = self.preprocess_input_df(rating_df)
             self.root_cluster = self.cluster_users_by_rating()
 
             # depth is the level of the hierarchy
@@ -58,18 +61,13 @@ class HierarchicalCluster:
             with open(clustered_result_path(dataset_name), 'wb') as cluster_file_w:
                 pickle.dump(self, cluster_file_w)
 
-    def preprocess_and_fillna(self, rating_df):
+    def preprocess_input_df(self, rating_df):
         matrix_builder = MatrixBuilder(rating_df)
         rating_matrix = matrix_builder.rating_matrix
 
         # TODO: consider other options for the fillna
         # filling the missing data with the column-wise (item-wise) average rating of the item
         return rating_matrix.fillna(rating_matrix.mean(), axis=0)
-
-    def reduce_dimensions(self):
-        # reduce the dimensions of rating_matrix by running PCA
-
-        return
 
     def cluster_users_by_rating(self):
         root_cluster = self.UserCluster(is_root=True)

--- a/survey/backend/src/strategies/preprocessing/matrix_builder.py
+++ b/survey/backend/src/strategies/preprocessing/matrix_builder.py
@@ -19,15 +19,17 @@ class MatrixBuilder:
         self.original_unique_items_cnt = len(self.original_unique_items)
 
         self.rating_matrix = self.densify_the_ratings_df(self.rating_df)
-        self.drop_users_or_items_with_few_ratings()
+
+        # optional data processing: dropping users or items with too few ratings
+        # self.drop_users_or_items_with_few_ratings()
 
     def drop_users_or_items_with_few_ratings(self):
 
         # TODO: CAVEAT: if # users is less than 1% of # items, it will drop everything
         # In this condition, the application is unlikely to return valid clustering anyways.
-        # items rated by more than 1% of the users
+        # drop items rated by less than 1% of the users
         self.rating_matrix = self.rating_matrix.dropna(axis='columns', thresh=self.original_unique_users_cnt * 0.1)
-        # users who rated more than 1% of the items
+        # drop users who rated less than 1% of the items
         self.rating_matrix = self.rating_matrix.dropna(axis='index', thresh=self.original_unique_items_cnt * 0.01)
 
     def densify_the_ratings_df(self, rating_df: pd.DataFrame) -> pd.DataFrame:

--- a/survey/backend/src/strategies/preprocessing/unittests.py
+++ b/survey/backend/src/strategies/preprocessing/unittests.py
@@ -38,10 +38,10 @@ Expected to be clustered: (((459), (477)), ((298), (219)))
 DATASET_PATH = '../../../data/datasets/'
 
 TEST1_DATASET_NAME = 'test1'
-DUMMY_RATINGS2 = pd.read_csv(raw_dataset_path(TEST1_DATASET_NAME))
+TEST1_DF = pd.read_csv(raw_dataset_path(TEST1_DATASET_NAME))
 
 TEST2_DATASET_NAME = 'test2'
-DUMMY_RATINGS3 = pd.read_csv(raw_dataset_path(TEST2_DATASET_NAME))
+TEST2_DF = pd.read_csv(raw_dataset_path(TEST2_DATASET_NAME))
 
 SAMPLE_DATASET_PATH = 'movielens_small'
 SAMPLE_DATA = pd.read_csv(raw_dataset_path(SAMPLE_DATASET_PATH))
@@ -52,7 +52,7 @@ class MatrixBuilderTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.matrix_builder = MatrixBuilder(DUMMY_RATINGS2)
+        cls.matrix_builder = MatrixBuilder(TEST1_DF)
         cls.compressed_df = cls.matrix_builder.rating_df
 
     # tests if the data frame from the `ratings.csv` is successfully transposed so that the columns are the items
@@ -80,6 +80,11 @@ class HierarchicalClusterTest(unittest.TestCase):
         cls.addClassCleanup(os.remove, clustered_result_path(TEST1_DATASET_NAME))
         cls.hc2 = HierarchicalCluster(TEST2_DATASET_NAME)
 
+    def test_if_user_ids_were_set_as_index(self):
+        raw_user_ids = TEST1_DF['userId'].unique()
+        raw_user_ids.sort()
+        assert self.hc1.rating_matrix.index.tolist() == list(raw_user_ids)
+
     def test_HC_clusters_into_two_given_users_less_than_5(self):
         root_cluster = self.hc1.root_cluster
         assert len(root_cluster.child_clusters) == 2
@@ -93,7 +98,7 @@ class HierarchicalClusterTest(unittest.TestCase):
 
     def test_root_cluster_contains_all_users(self):
         # using set instead of unique for sorting
-        user_ids = DUMMY_RATINGS2['userId'].unique()
+        user_ids = TEST1_DF['userId'].unique()
         user_ids.sort()
         assert self.hc1.root_cluster.user_ids == user_ids.tolist()
 

--- a/survey/backend/src/strategies/preprocessing/unittests.py
+++ b/survey/backend/src/strategies/preprocessing/unittests.py
@@ -87,9 +87,9 @@ class HierarchicalClusterTest(unittest.TestCase):
     def test_HC_clusters_into_right_depth(self):
         assert self.hc1.depth == 2
 
-    def test_HC_clusters_into_two_given_users_more_than_5(self):
+    def test_HC_clusters_into_five_given_users_more_than_5(self):
         root_cluster = self.hc2.root_cluster
-        assert len(root_cluster.child_clusters) == 3
+        assert len(root_cluster.child_clusters) == 5
 
     def test_root_cluster_contains_all_users(self):
         # using set instead of unique for sorting


### PR DESCRIPTION
This PR changes the pre-processing of the input data frame (ratings).
1. It reduces the dimension by PCA at every hierarchy.  For example, if the hierarchical clustering goes down to 5 levels of hierarchy running 5 times, it will run the PCA at each level.
2. Instead of picking the desirable k for the clustering, it always clusters to constant k, 5. Running elbow method at every clustering is too expensive, making the process very slow. The constant, 5,  was chosen as a common number of options in each question. When the elbow method picks the desirable k, it can return 200 clusters. In this case, the user will have to consider 200 representative items to choose from.