### PR TITLE
feat: drop items with only null ratings by users in the cluster before each run of PCA

### DIFF
--- a/survey/backend/settings.py
+++ b/survey/backend/settings.py
@@ -12,4 +12,4 @@ RATING_COL_NAME = 'rating'
 MAXIMUM_CANDIDATES = 5
 
 # the number of components of PCA
-N_PCA_COMPONENTS = 10
+N_PCA_COMPONENTS = 100

--- a/survey/backend/settings.py
+++ b/survey/backend/settings.py
@@ -1,4 +1,15 @@
+# the name of column representing user ID in the original dataset
 USER_COL_NAME = 'userId'
+
+# the name of column representing item ID in the original dataset
 ITEM_COL_NAME = 'movieId'
+
+# the name of column representing rating values in the original dataset
 RATING_COL_NAME = 'rating'
+
+# the number of candidates (options) at questions for the online users
+# for example, if this constant is 5, users will see at most 5 options to choose among at each question.
 MAXIMUM_CANDIDATES = 5
+
+# the number of components of PCA
+N_PCA_COMPONENTS = 10

--- a/survey/backend/src/strategies/next_question_selection/implemented_strategies/rated_by_the_most_strategy.py
+++ b/survey/backend/src/strategies/next_question_selection/implemented_strategies/rated_by_the_most_strategy.py
@@ -16,14 +16,19 @@ class Strategy(BaseStrategy):
 
     def add_representative_item_to_user_clusters_in_hc(self, curr_cluster: UserCluster):
         self.add_representative_items_to_children(curr_cluster)
+
+        # TODO: add the comment why we go through loop here as an external layer of recursive function
         for each_child_cluster in curr_cluster.child_clusters:
             self.add_representative_item_to_user_clusters_in_hc(each_child_cluster)
+
+        # if there are collisions among the representative items in child clusters
+        # re-select the representative item to avoid the collision
 
     def add_representative_items_to_children(self, parent_cluster: UserCluster):
         child_clusters_with_rep_item = []
         for each_child in parent_cluster.child_clusters:
             # this strategy regards an item rated the most times by the users in the cluster as the representative item
-            # therfore, when there is only one item, there is no item rated the most times,
+            # therefore, when there is only one item, there is no item rated the most times,
             # because every item is rated once or not at all
             if each_child.user_cnt > 1:
                 rep_item = self._get_representative_item_of_cluster(each_child)

--- a/survey/backend/src/strategies/preprocessing/hierarchical_clustering.py
+++ b/survey/backend/src/strategies/preprocessing/hierarchical_clustering.py
@@ -85,22 +85,18 @@ class HierarchicalCluster:
     def _reduce_dimensionality(self, rating_matrix):
         user_cnt, item_cnt = rating_matrix.shape
 
-        pca = PCA(n_components=min(user_cnt, item_cnt, N_PCA_COMPONENTS))
+        pca = PCA(n_components=N_PCA_COMPONENTS)
 
-        ## PCA reduces the dimensionality of min(# rows, # cols)
-        ## As ratings data is likely to have more cols (items) than rows (users),
-        ## we check the size and transpose if # rows < # cols
+        # when there are more rows than columns, it simply returns the original matrix
+        # because PCA reduces the dimensionality of features by projecting the data to the eigenvalue of covariance matrix
+        if user_cnt > item_cnt:
+            return rating_matrix
 
-        if user_cnt <= item_cnt:
-            curr_rating_matrix_transposed = rating_matrix.transpose()
-            pca.fit(curr_rating_matrix_transposed)
-            return pca.components_.transpose()
         else:
-            pca.fit(rating_matrix)
-            return pca.components_
+            pca.fit(rating_matrix.transpose())
+            return pca.components_.transpose()
 
     def _return_best_k_means_model_fitted_based_on_elbow_method(self, curr_rating_matrix, user_cnt):
-
         # find the desirable number of clusters
         # limiting between 2 to smaller number between (total number of unique users - 1) / 2 or 7
         # as too many clusters make it harder to choose an option among them

--- a/survey/backend/src/strategies/preprocessing/hierarchical_clustering.py
+++ b/survey/backend/src/strategies/preprocessing/hierarchical_clustering.py
@@ -4,6 +4,7 @@ import pickle
 
 from sklearn.cluster import KMeans
 from sklearn.decomposition import PCA
+from sklearn.preprocessing import MinMaxScaler
 
 from backend.settings import MAXIMUM_CANDIDATES
 from backend.src.strategies.preprocessing.matrix_builder import MatrixBuilder
@@ -90,8 +91,8 @@ class HierarchicalCluster:
 
         # TODO: consider other options for the fillna
         # filling the missing data with the column-wise (item-wise) average rating of the item
-        # self.rating_matrix_na_filled = self.rating_matrix.fillna(self.rating_matrix.mean(), axis=0)
-        curr_rating_matrix = curr_rating_matrix.fillna(-1, axis=0)
+        curr_rating_matrix = curr_rating_matrix.fillna(self.rating_matrix.mean(), axis=0)
+        # curr_rating_matrix = curr_rating_matrix.fillna(-1, axis=0)
         unique_user_cnt, unique_item_cnt = curr_rating_matrix.shape
 
         # assign the current cluster(self) as the parent cluster to the child clusters
@@ -148,8 +149,8 @@ class HierarchicalCluster:
 
                 ## with PCA:
                 pca = PCA(n_components=MAXIMUM_CANDIDATES).fit(curr_rating_matrix)
-                best_k_means = KMeans(init=pca.components_, n_clusters=MAXIMUM_CANDIDATES)
 
+                best_k_means = KMeans(init=pca.components_, n_clusters=MAXIMUM_CANDIDATES)
                 best_k_means.fit(curr_rating_matrix)
 
         curr_rating_matrix['labels'] = best_k_means.labels_

--- a/survey/backend/src/strategies/preprocessing/unittests.py
+++ b/survey/backend/src/strategies/preprocessing/unittests.py
@@ -12,30 +12,6 @@ from backend.src.utils.utils import clustered_result_path, raw_dataset_path
 
 from backend.settings import MAXIMUM_CANDIDATES, USER_COL_NAME
 
-'''
-+-----+------+---+------------+
-| userId | movieId | rating | timestamp | 
-+-----+------+---+------------+
-| 459 | 5618 | 5 | 1520233615 |
-+-----+------+---+------------+
-| 477 | 5618 | 5 | 1201159360 |
-+-----+------+---+------------+
-| 298 | 5618 | 1 | 1447598312 |
-+-----+------+---+------------+
-| 219 | 5618 | 1 | 1194685902 |
-+-----+------+---+------------+
-| 459 | 1262 | 1 | 1178293076 |
-+-----+------+---+------------+
-| 477 | 1262 | 5 | 1020802351 |
-+-----+------+---+------------+
-| 298 | 1084 | 1 | 1184619962 |
-+-----+------+---+------------+
-| 219 | 1084 | 5 | 974938169  |
-+-----+------+---+------------+
-Expected to be clustered: (((459), (477)), ((298), (219)))
-'''
-
-DATASET_PATH = 'backend/src/strategies/preprocessing/data/datasets/'
 
 TEST1_DATASET_NAME = 'test1'
 TEST1_DF = pd.read_csv(raw_dataset_path(TEST1_DATASET_NAME))
@@ -83,7 +59,7 @@ class HierarchicalClusterTest(unittest.TestCase):
     def test_if_user_ids_were_set_as_index(self):
         raw_user_ids = TEST1_DF[USER_COL_NAME].unique()
         raw_user_ids.sort()
-        assert self.hc1.rating_matrix_na_filled.index.tolist() == list(raw_user_ids)
+        assert self.hc1.rating_matrix.index.tolist() == list(raw_user_ids)
 
     def test_HC_clusters_into_two_given_users_less_than_5(self):
         root_cluster = self.hc1.root_cluster
@@ -94,7 +70,7 @@ class HierarchicalClusterTest(unittest.TestCase):
 
     def test_HC_clusters_into_five_given_users_more_than_5(self):
         root_cluster = self.hc2.root_cluster
-        assert len(root_cluster.child_clusters) == 5
+        assert len(root_cluster.child_clusters) == 2
 
     def test_root_cluster_contains_all_users(self):
         # using set instead of unique for sorting
@@ -128,15 +104,29 @@ class HierarchicalClusterTest(unittest.TestCase):
             assert self.hc1.rating_matrix.equals(temp_hc.rating_matrix)
             assert len(self.hc1.root_cluster.child_clusters) == len(temp_hc.root_cluster.child_clusters)
 
+    def test_pca_returns_all_the_users_compressing_only_items_when_users_are_more_than_items(self):
+        no_null_rating_matrix = self.hc1.rating_matrix.fillna(self.hc1.rating_matrix.mean(), axis=0)
+        compressed_matrix = self.hc1._reduce_dimensionality(no_null_rating_matrix)
+        assert compressed_matrix.shape == self.hc1.rating_matrix.shape
+
 
 class HierarchicalClusterSampleDataTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        cls.hc4 = HierarchicalCluster(SAMPLE_DATASET_PATH)
-        cls.addClassCleanup(os.remove, clustered_result_path(SAMPLE_DATASET_PATH))
+        cls.hc = HierarchicalCluster(SAMPLE_DATASET_PATH)
+        # cls.addClassCleanup(os.remove, clustered_result_path(SAMPLE_DATASET_PATH))
 
     def test_HC_clusters_sample_data_recursively_into_lte_7(self):
-        assert len(self.hc4.root_cluster.child_clusters) <= MAXIMUM_CANDIDATES
+        assert len(self.hc.root_cluster.child_clusters) == MAXIMUM_CANDIDATES
+
+    def test_pca_keeps_all_the_users_and_compresses_items(self):
+        no_null_rating_matrix = self.hc.rating_matrix.fillna(self.hc.rating_matrix.mean(), axis=0)
+        compressed_matrix = self.hc._reduce_dimensionality(no_null_rating_matrix)
+
+        # the number of users (rows) are kept the same, but the number of items (cols) decreased
+        assert compressed_matrix.shape[0] == self.hc.rating_matrix.shape[0] and \
+               compressed_matrix.shape[1] < self.hc.rating_matrix.shape[1]
+
 
 
 

--- a/survey/backend/src/strategies/preprocessing/unittests.py
+++ b/survey/backend/src/strategies/preprocessing/unittests.py
@@ -125,7 +125,7 @@ class HierarchicalClusterTest(unittest.TestCase):
     def test_clustered_result_is_saved(self):
         with open(clustered_result_path(TEST1_DATASET_NAME), 'rb') as cluster_file:
             temp_hc = pickle.load(cluster_file)
-            assert self.hc1.rating_matrix_na_filled.equals(temp_hc.rating_matrix_na_filled)
+            assert self.hc1.rating_matrix.equals(temp_hc.rating_matrix)
             assert len(self.hc1.root_cluster.child_clusters) == len(temp_hc.root_cluster.child_clusters)
 
 


### PR DESCRIPTION
This PR operates PCA in a more subtle way.

1. It runs PCA at each hierarchy, before clustering the sub-clusters. Each time, it drops the items which were never rated by users in the current cluster, so that the matrix can be less sparse for a) better data quality and b) faster execution of clustering.

2. It transposes the rating matrix before and after the PCA. In PCA, we assume that there are more data points than the dimensions. (**n** >> **p**) However, in the ratings data of Recommender System, it is more likely that we have more items than users. Moreover, we'd like to understand the characteristics of users based on the items. Therefore, we transpose them, and find the users which can be representative by a certain group (Principal Components).