### PR TITLE
feat: implement manic strategy

### DIFF
--- a/survey/backend/src/strategies/next_question_selection/implemented_strategies/maniac_strategy.py
+++ b/survey/backend/src/strategies/next_question_selection/implemented_strategies/maniac_strategy.py
@@ -1,0 +1,16 @@
+import os
+
+from backend.src.strategies.next_question_selection.abstract_class.item_selection_base_choice import BaseStrategyChoice
+from backend.src.utils.utils import convert_current_ratings_str_into_list
+
+from backend.src.strategies.preprocessing.hierarchical_clustering import UserCluster
+from backend.src.strategies.next_question_selection.user_cluster_with_representative_item import UserClusterRep, \
+    get_cluster_matched_up_to_now
+
+
+class Strategy(BaseStrategyChoice):
+    strategy_name = 'maniac'
+
+    def __init__(self, dataset_name: str):
+        super(Strategy, self).__init__(dataset_name)
+

--- a/survey/backend/src/strategies/next_question_selection/implemented_strategies/maniac_strategy.py
+++ b/survey/backend/src/strategies/next_question_selection/implemented_strategies/maniac_strategy.py
@@ -14,3 +14,48 @@ class Strategy(BaseStrategyChoice):
     def __init__(self, dataset_name: str):
         super(Strategy, self).__init__(dataset_name)
 
+    def add_representative_item_to_user_clusters_in_hc(self, curr_cluster: UserCluster):
+        self.add_representative_items_to_children(curr_cluster)
+        for each_child_cluster in curr_cluster.child_clusters:
+            self.add_representative_item_to_user_clusters_in_hc(each_child_cluster)
+
+    def add_representative_items_to_children(self, parent_cluster: UserCluster):
+        child_clusters_with_rep_item = []
+        for each_child in parent_cluster.child_clusters:
+            # this strategy regards an item with the most drastic ratings
+            rep_item = self._get_representative_item_of_cluster(each_child)
+            user_cluster_with_rep_item = UserClusterRep(each_child, rep_item)
+            child_clusters_with_rep_item.append(user_cluster_with_rep_item)
+        parent_cluster.child_clusters = child_clusters_with_rep_item
+
+    def _get_representative_item_of_cluster(self, cluster: UserCluster) -> int:
+
+        # select item ratings by the users in each cluster in the data frame
+        df_items_rated_by_the_cluster = self.clustering.rating_matrix.filter(items=cluster.user_ids, axis='rows')
+        df_items_not_rated_by_the_cluster = self.clustering.rating_matrix[~self.clustering.rating_matrix.index.isin(cluster.user_ids)]
+
+        mean_diff = df_items_rated_by_the_cluster.fillna(-1).mean() - \
+                    df_items_not_rated_by_the_cluster.fillna(-1).mean()
+
+        return mean_diff.sort_values(ascending=False).first_valid_index()
+
+    def has_next(self, choices_so_far_str: str) -> bool:
+        choices_so_far = convert_current_ratings_str_into_list(choices_so_far_str)
+        curr_cluster = get_cluster_matched_up_to_now(self.clustering.root_cluster, choices_so_far)
+
+        # we can expect next item until we reach the cluster with only one user
+        return curr_cluster.user_cnt > 1
+
+    def get_next_items(self, choices_so_far_str: str) -> [int]:
+        choices_so_far = convert_current_ratings_str_into_list(choices_so_far_str)
+        # find the cluster that the user is matched depending on the choices up to now
+        curr_cluster = get_cluster_matched_up_to_now(self.clustering.root_cluster, choices_so_far)
+
+        if curr_cluster.user_cnt > 1:
+            # return the representative items of the child clusters of the matched cluster up to now
+            return [each_child.rep_item for each_child in curr_cluster.child_clusters]
+        else:
+            return []
+
+
+

--- a/survey/backend/src/strategies/next_question_selection/tests/unittests.py
+++ b/survey/backend/src/strategies/next_question_selection/tests/unittests.py
@@ -132,11 +132,28 @@ class FavoriteItemStrategyTestSampleData(unittest.TestCase):
         assert matched_cluster.user_ids == [414]
 
 
-class ManiacItemsStrategyTestSampleData(unittest.TestCase):
+class ManiacItemsStrategyTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.maniac_strategy = s_maniac('movielens_small')
+        cls.maniac_strategy = s_maniac('test2')
 
+    def test_first_clustering(self):
+        root_cluster = self.maniac_strategy.clustering.root_cluster
+        first_child_clusters = [each.user_ids for each in root_cluster.child_clusters]
+        assert [219, 412] in first_child_clusters and \
+            [297, 298, 459, 477] in first_child_clusters
 
+    def test_maniac_strategy_picks_items_rated_the_most_drastic(self):
+        # [219, 412] cluster's maniac choice: item 1084
+        # [297, 298, 459, 477] cluster's maniac choice: 5618
 
+        root_cluster = self.maniac_strategy.clustering.root_cluster
+
+        if root_cluster.child_clusters[0].user_ids == [219, 412]:
+            child_cluster1, child_cluster2 = root_cluster.child_clusters[0], root_cluster.child_clusters[1]
+        else:
+            child_cluster1, child_cluster2 = root_cluster.child_clusters[1], root_cluster.child_clusters[0]
+
+        assert child_cluster1.rep_item == 1084
+        assert child_cluster2.rep_item == 1262

--- a/survey/backend/src/strategies/next_question_selection/tests/unittests.py
+++ b/survey/backend/src/strategies/next_question_selection/tests/unittests.py
@@ -6,6 +6,8 @@ from backend.src.strategies.next_question_selection.implemented_strategies.rando
     Strategy as s_random
 from backend.src.strategies.next_question_selection.implemented_strategies.favorite_item_strategy import \
     Strategy as s_favorite
+from backend.src.strategies.next_question_selection.implemented_strategies.maniac_strategy import \
+    Strategy as s_maniac
 
 from backend.src.strategies.next_question_selection.user_cluster_with_representative_item import \
     get_cluster_matched_up_to_now
@@ -128,6 +130,13 @@ class FavoriteItemStrategyTestSampleData(unittest.TestCase):
         matched_cluster = get_cluster_matched_up_to_now(self.favorite_strategy.clustering.root_cluster, [1262])
         assert matched_cluster.user_cnt == 1
         assert matched_cluster.user_ids == [414]
+
+
+class ManiacItemsStrategyTestSampleData(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.maniac_strategy = s_maniac('movielens_small')
 
 
 


### PR DESCRIPTION
This PR implements a new questioning strategy, the Maniac strategy.
Maniac strategy picks an item rated exceptionally high by a particular cluster compared to others. More specifically, this strategy regards an item as a representative item when the difference between its average rating in this cluster and that in others is the biggest.  

This PR includes unit tests.