### PR TITLE
fix: fix the least_diff matching strategy

### DIFF
--- a/survey/backend/settings.py
+++ b/survey/backend/settings.py
@@ -11,5 +11,9 @@ RATING_COL_NAME = 'rating'
 # for example, if this constant is 5, users will see at most 5 options to choose among at each question.
 MAXIMUM_CANDIDATES = 5
 
+# maximum value of rating
+MAX_RATING = 5
+MIN_RATING = 0
+
 # the number of components of PCA
 N_PCA_COMPONENTS = 100

--- a/survey/backend/src/strategies/evaluation/eval_runner.py
+++ b/survey/backend/src/strategies/evaluation/eval_runner.py
@@ -58,7 +58,7 @@ def print_t_test_result(dataset_name, matching_strategies, questioning_strategie
         return hit_ratio_samples
 
     CONTROL_MATCHING_STRATEGY = matching_random
-    CONTROL_QUESTIONING_STRATEGY = questioning_rated_most
+    CONTROL_QUESTIONING_STRATEGY = questioning_random
 
     control_hit_ratios = collect_hit_ratio(dataset_name, CONTROL_QUESTIONING_STRATEGY,
                                            CONTROL_MATCHING_STRATEGY, sample_size, n_samples)

--- a/survey/backend/src/strategies/evaluation/eval_runner.py
+++ b/survey/backend/src/strategies/evaluation/eval_runner.py
@@ -93,7 +93,7 @@ matching_strategies = [matching_random, matching_least_diff]
 
 ## T-test
 SAMPLE_SIZE = 100
-N_SAMPLES = 1000
+N_SAMPLES = 100
 
 # print_t_test_result(test_dataset_name, matching_strategies, questioning_strategies, SAMPLE_SIZE, N_SAMPLES)
 print_t_test_result(test_dataset_name, matching_strategies, [questioning_rated_most], SAMPLE_SIZE, N_SAMPLES)

--- a/survey/backend/src/strategies/evaluation/eval_runner.py
+++ b/survey/backend/src/strategies/evaluation/eval_runner.py
@@ -34,9 +34,10 @@ def print_eval_result(dataset_name, repeating_times, questioning_strategies, mat
                                                                                  each_matching_strategy.strategy_name,
                                                                                  hit_ratio,
                                                                                  round(end-start, 5)))
+    print("")
 
 
-def print_t_test_result(dataset_name, questioning_strategies, sample_size, n_samples):
+def print_t_test_result(dataset_name, matching_strategies, questioning_strategies, sample_size, n_samples):
     '''
 
     Returns:
@@ -56,45 +57,46 @@ def print_t_test_result(dataset_name, questioning_strategies, sample_size, n_sam
 
         return hit_ratio_samples
 
-    BASE_MATCHING_STRATEGY = matching_random
-    CONTROL_GROUP_QUESTIONING_STRATEGY = questioning_random
+    CONTROL_MATCHING_STRATEGY = matching_random
+    CONTROL_QUESTIONING_STRATEGY = questioning_rated_most
 
-    control_hit_ratios = collect_hit_ratio(dataset_name, CONTROL_GROUP_QUESTIONING_STRATEGY,
-                                           BASE_MATCHING_STRATEGY, sample_size, n_samples)
+    control_hit_ratios = collect_hit_ratio(dataset_name, CONTROL_QUESTIONING_STRATEGY,
+                                           CONTROL_MATCHING_STRATEGY, sample_size, n_samples)
 
-    for each_q_strategy in questioning_strategies:
-        test_hit_ratios = collect_hit_ratio(dataset_name, each_q_strategy,
-                                            BASE_MATCHING_STRATEGY, sample_size, n_samples)
+    for each_m_strategy in matching_strategies:
+        for each_q_strategy in questioning_strategies:
+            test_hit_ratios = collect_hit_ratio(dataset_name, each_q_strategy, each_m_strategy, sample_size, n_samples)
 
-        t_test_result = stats.ttest_ind(a=control_hit_ratios, b=test_hit_ratios, equal_var=True)
-        print(
-            f'## T-test result of [{each_q_strategy.strategy_name}] (sample_size={sample_size}, n_samples={n_samples})')
+            t_test_result = stats.ttest_ind(a=control_hit_ratios, b=test_hit_ratios, equal_var=True)
+            print(
+                f'## T-test result of [q={each_q_strategy.strategy_name}, m={each_m_strategy.strategy_name}] (sample_size={sample_size}, n_samples={n_samples})')
 
-        print(f'- Avg hit ratio of ctrl strategy: {round(sum(control_hit_ratios) / len(control_hit_ratios), 3)}')
-        print(f'- Avg hit ratio of test strategy: {round(sum(test_hit_ratios) / len(test_hit_ratios), 3)}')
+            print(f'- Avg hit ratio of ctrl strategy: {round(sum(control_hit_ratios) / len(control_hit_ratios), 3)}')
+            print(f'- Avg hit ratio of test strategy: {round(sum(test_hit_ratios) / len(test_hit_ratios), 3)}')
 
-        if t_test_result.pvalue < 0.05:
-            print(f'- Result: REJECT null hypothesis (p-value: {t_test_result.pvalue})\n')
-        else:
-            print(f'- Result: ACCEPT null hypothesis (p-value: {t_test_result.pvalue})\n')
+            if t_test_result.pvalue < 0.05:
+                print(f'- Result: REJECT null hypothesis (p-value: {t_test_result.pvalue})\n')
+            else:
+                print(f'- Result: ACCEPT null hypothesis (p-value: {t_test_result.pvalue})\n')
 
 
-test_dataset_name = 'movielens_small'
+test_dataset_name = 'ml-1m'
 test_repeating_times = 100
 
 # USER GUIDE: add the  questioning strategies to evaluate here
 questioning_strategies = [questioning_random, questioning_favorite, questioning_rated_most, questioning_maniac]
 # USER GUIDE: add the  matching strategies to evaluate here
-matching_strategies = [matching_random]
+matching_strategies = [matching_random, matching_least_diff]
 
 # print_eval_result(test_dataset_name, test_repeating_times, questioning_strategies, matching_strategies)
 
 
 ## T-test
 SAMPLE_SIZE = 100
-N_SAMPLES = 100
+N_SAMPLES = 1000
 
-print_t_test_result(test_dataset_name, questioning_strategies, SAMPLE_SIZE, N_SAMPLES)
+# print_t_test_result(test_dataset_name, matching_strategies, questioning_strategies, SAMPLE_SIZE, N_SAMPLES)
+print_t_test_result(test_dataset_name, matching_strategies, [questioning_rated_most], SAMPLE_SIZE, N_SAMPLES)
 
 
 

--- a/survey/backend/src/strategies/evaluation/t-test_results/t-test_ml-100k.txt
+++ b/survey/backend/src/strategies/evaluation/t-test_results/t-test_ml-100k.txt
@@ -1,19 +1,32 @@
-## T-test result of [random_item] (sample_size=100, n_samples=200)
+## T-test result of [q=random_item, m=random] (sample_size=100, n_samples=100)
 - Avg hit ratio of ctrl strategy: 0.001
 - Avg hit ratio of test strategy: 0.001
-- Result: ACCEPT null hypothesis (p-value: 0.21804686066388645)
+- Result: ACCEPT null hypothesis (p-value: 0.8365208634560879)
 
-## T-test result of [favorite_item] (sample_size=100, n_samples=200)
+## T-test result of [q=favorite_item, m=random] (sample_size=100, n_samples=100)
 - Avg hit ratio of ctrl strategy: 0.001
-- Avg hit ratio of test strategy: 0.005
-- Result: REJECT null hypothesis (p-value: 7.173512026693515e-13)
+- Avg hit ratio of test strategy: 0.006
+- Result: REJECT null hypothesis (p-value: 6.992933651999333e-10)
 
-## T-test result of [rated_by_the_most] (sample_size=100, n_samples=200)
+## T-test result of [q=rated_by_the_most, m=random] (sample_size=100, n_samples=100)
+- Avg hit ratio of ctrl strategy: 0.001
+- Avg hit ratio of test strategy: 0.007
+- Result: REJECT null hypothesis (p-value: 2.512398597589131e-10)
+
+## T-test result of [q=maniac, m=random] (sample_size=100, n_samples=100)
+- Avg hit ratio of ctrl strategy: 0.001
+- Avg hit ratio of test strategy: 0.016
+- Result: REJECT null hypothesis (p-value: 1.8725746949413625e-24)
+
+
+---
+
+## T-test result of [q=rated_by_the_most, m=random] (sample_size=100, n_samples=100)
+- Avg hit ratio of ctrl strategy: 0.001
+- Avg hit ratio of test strategy: 0.007
+- Result: REJECT null hypothesis (p-value: 7.899762262994867e-12)
+
+## T-test result of [q=rated_by_the_most, m=least_diff] (sample_size=100, n_samples=100)
 - Avg hit ratio of ctrl strategy: 0.001
 - Avg hit ratio of test strategy: 0.008
-- Result: REJECT null hypothesis (p-value: 1.2668357414309287e-21)
-
-## T-test result of [maniac] (sample_size=100, n_samples=200)
-- Avg hit ratio of ctrl strategy: 0.001
-- Avg hit ratio of test strategy: 0.015
-- Result: REJECT null hypothesis (p-value: 5.521132858307902e-45)
+- Result: REJECT null hypothesis (p-value: 5.39836639505973e-13)

--- a/survey/backend/src/strategies/evaluation/t-test_results/t-test_ml_1m.txt
+++ b/survey/backend/src/strategies/evaluation/t-test_results/t-test_ml_1m.txt
@@ -20,3 +20,12 @@
 
 ---
 
+## T-test result of [q=rated_by_the_most, m=random] (sample_size=100, n_samples=100)
+- Avg hit ratio of ctrl strategy: 0.0
+- Avg hit ratio of test strategy: 0.0
+- Result: ACCEPT null hypothesis (p-value: 0.4096329908519074)
+
+## T-test result of [q=rated_by_the_most, m=least_diff] (sample_size=100, n_samples=100)
+- Avg hit ratio of ctrl strategy: 0.0
+- Avg hit ratio of test strategy: 0.0
+- Result: ACCEPT null hypothesis (p-value: 0.4096329908519074)

--- a/survey/backend/src/strategies/evaluation/t-test_results/t-test_ml_1m.txt
+++ b/survey/backend/src/strategies/evaluation/t-test_results/t-test_ml_1m.txt
@@ -1,0 +1,22 @@
+## T-test result of [q=random_item, m=random] (sample_size=100, n_samples=100)
+- Avg hit ratio of ctrl strategy: 0.0
+- Avg hit ratio of test strategy: 0.0
+- Result: ACCEPT null hypothesis (p-value: 0.31484613749499046)
+
+## T-test result of [q=favorite_item, m=random] (sample_size=100, n_samples=100)
+- Avg hit ratio of ctrl strategy: 0.0
+- Avg hit ratio of test strategy: 0.0
+- Result: ACCEPT null hypothesis (p-value: 1.0)
+
+## T-test result of [q=rated_by_the_most, m=random] (sample_size=100, n_samples=100)
+- Avg hit ratio of ctrl strategy: 0.0
+- Avg hit ratio of test strategy: 0.001
+- Result: ACCEPT null hypothesis (p-value: 0.05477361521063713)
+
+## T-test result of [q=maniac, m=random] (sample_size=100, n_samples=100)
+- Avg hit ratio of ctrl strategy: 0.0
+- Avg hit ratio of test strategy: 0.006
+- Result: REJECT null hypothesis (p-value: 1.7101399632188848e-12)
+
+---
+

--- a/survey/backend/src/strategies/evaluation/t-test_results/t-test_movielens_small.txt
+++ b/survey/backend/src/strategies/evaluation/t-test_results/t-test_movielens_small.txt
@@ -17,3 +17,16 @@
 - Avg hit ratio of ctrl strategy: 0.002
 - Avg hit ratio of test strategy: 0.02
 - Result: REJECT null hypothesis (p-value: 4.698996397648275e-31)
+
+
+---
+
+## T-test result of [q=rated_by_the_most, m=random] (sample_size=100, n_samples=100)
+- Avg hit ratio of ctrl strategy: 0.001
+- Avg hit ratio of test strategy: 0.007
+- Result: REJECT null hypothesis (p-value: 9.477958421778748e-09)
+
+## T-test result of [q=rated_by_the_most, m=least_diff] (sample_size=100, n_samples=100)
+- Avg hit ratio of ctrl strategy: 0.001
+- Avg hit ratio of test strategy: 0.006
+- Result: REJECT null hypothesis (p-value: 9.803922732371887e-09)

--- a/survey/backend/src/strategies/matchmaking/implemented_strategies/random_matchmaking_strategy.py
+++ b/survey/backend/src/strategies/matchmaking/implemented_strategies/random_matchmaking_strategy.py
@@ -7,5 +7,6 @@ class Strategy(BaseStrategy):
     strategy_name = 'random'
 
     def get_matched_user_id_among_multiple_in_cluster(self) -> int:
+        # as this is a random matching, given online_user_id is not in use
         reproducible_random_state = random.RandomState(97)
         return int(reproducible_random_state.choice(self.matched_cluster.user_ids))


### PR DESCRIPTION
This PR fixes the wrong assumption with matching_least_diff strategy. It assumed the survey response will be in form of [{`item_id`: `rating_value`}, ....], but my implementation follows picking an item without a rating. Hence, the matching strategy is fixed to accept only the item IDs.